### PR TITLE
PIEUSLA-374: Make module Drupal 9 compatible

### DIFF
--- a/aws_sqs.info.yml
+++ b/aws_sqs.info.yml
@@ -2,5 +2,6 @@ name: Amazon SQS Queue Interface
 description: Defines a Queue Interface for Amazon SQS
 package: Queues
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
-configure : aws_sqs.settings
+configure: aws_sqs.settings

--- a/aws_sqs.info.yml
+++ b/aws_sqs.info.yml
@@ -5,3 +5,4 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 type: module
 configure: aws_sqs.settings
+version: 0.5.0

--- a/src/AwsSqsQueueFactory.php
+++ b/src/AwsSqsQueueFactory.php
@@ -62,7 +62,7 @@ class AwsSqsQueueFactory {
   protected function getClient() {
     if (!isset($this->client)) {
       $credentials = new Credentials($this->config->get('aws_sqs_aws_key'), $this->config->get('aws_sqs_aws_secret'));
-      $this->client = SqsClient::factory([
+      $this->client = new SqsClient([
         'credentials' => $credentials,
         'region' => $this->config->get('aws_sqs_region', 'us-east-1'),
         'version' => $this->config->get('aws_sqs_version', 'latest'),


### PR DESCRIPTION
## Overview
We need to update one of client sites to Drupal 9, and in order to do this we need to update this module too as it's used on that site. 

## Technical details
1. To make module compatible with Drupal 9 we add `core_version_requirement: ^8 || ^9` to the info file.
2. Also to prepare a release we add `version: 0.5.0` to info file.
3. As part of this PR we slightly update `AwsSqsQueueFactory->getClient()` as well to fix the warning:
```
Call to deprecated method factory() of class Aws\AwsClient.
```